### PR TITLE
Trigger condition call flag to distinguish between writerows/deleterows events

### DIFF
--- a/lib/LiveMysqlSelect.js
+++ b/lib/LiveMysqlSelect.js
@@ -60,9 +60,12 @@ LiveMysqlSelect.prototype.matchRowEvent = function(event){
           row = event.rows[r];
           if(eventName === 'updaterows'){
             return trigger.condition.call(self, row.before, row.after);
+          }
+          else if(eventName === 'writerows'){
+            return trigger.condition.call(self, row.before, row.after, false);
           }else{
-            // writerows or deleterows
-            return trigger.condition.call(self, row);
+            // deleterows
+            return trigger.condition.call(self, row, true);
           }
         }
       }

--- a/lib/LiveMysqlSelect.js
+++ b/lib/LiveMysqlSelect.js
@@ -62,7 +62,7 @@ LiveMysqlSelect.prototype.matchRowEvent = function(event){
             return trigger.condition.call(self, row.before, row.after);
           }
           else if(eventName === 'writerows'){
-            return trigger.condition.call(self, row.before, row.after, false);
+            return trigger.condition.call(self, row, false);
           }else{
             // deleterows
             return trigger.condition.call(self, row, true);


### PR DESCRIPTION
An additional boolean argument (flag) is passed to the trigger condition call.

When it is false, it indicates that the row has been inserted (writerows event).

When it is true, it indicates that the row is being deleted (deleterows event).

This flag is used as input data for code that makes reactive table joins more efficient by caching the values of the fields used to join the tables.

Every time a new binary log event takes place, the caching code inspects this argument and can determine whether it should add the field to the cache or purge it.