### PR TITLE
Better caching that fixes two major bugs

### DIFF
--- a/lib/LiveMysql.js
+++ b/lib/LiveMysql.js
@@ -7,6 +7,7 @@ var mysql = require('mysql');
 var ZONGJI_INIT_TIMEOUT = 1500;
 
 var LiveMysqlSelect = require('./LiveMysqlSelect');
+var QueryCache = require('./QueryCache');
 
 function LiveMysql(settings, callback){
   var self = this;
@@ -16,8 +17,7 @@ function LiveMysql(settings, callback){
   self.zongji = null;
   self.db = db;
   self._select = [];
-  // Cache query results for any new, duplicate SELECT statements
-  self._resultsBuffer = {};
+  self._queryCache = {};
   self._schemaCache = {};
 
   self.zongjiSettings = {
@@ -34,36 +34,16 @@ function LiveMysql(settings, callback){
 
     zongji.on('binlog', function(event) {
       if(event.getEventName() === 'tablemap') return;
-      if(self._select.length === 0) return;
-
-      // Cache query results within this update event
-      var eventResults = {};
-
-      // Update each select statement if matches event
-      function _nextSelect(index){
-        var select;
-        if(index < self._select.length){
-          select = self._select[index];
-          if(select.matchRowEvent(event)){
-            if(select.query in eventResults){
-              select._setRows(eventResults[select.query]);
-              _nextSelect(index + 1);
-            }else{
-              select.update(function(error, rows){
-                if(error === undefined){
-                  eventResults[select.query] = rows;
-                }
-                _nextSelect(index + 1);
-              });
-            }
-          }else{
-            _nextSelect(index + 1);
-          }
+      
+      for(var query in self._queryCache){
+        if (!self._queryCache.hasOwnProperty(query)){
+          continue;
+        }
+        var queryCache = self._queryCache[query];
+        if(!queryCache.canSkipRowEvent() && queryCache.matchRowEvent(event)){
+          queryCache.invalidate();
         }
       }
-
-      _nextSelect(0);
-
     });
 
     // Wait for Zongji to be ready before executing callback
@@ -107,11 +87,55 @@ LiveMysql.prototype.select = function(query, triggers){
       includeSchema[triggerDatabase].push(triggers[i].table);
     }
   }
+  
+  query = self._escapeQueryFun(query);
+  
+  var queryCache;
+  if(self._queryCache.hasOwnProperty(query)){
+    queryCache = self._queryCache[query];
+  }else{
+    queryCache = new QueryCache(query, this);
+    self._queryCache[query] = queryCache;
+  }
 
-  var newSelect = new LiveMysqlSelect(query, triggers, this);
+  var newSelect = new LiveMysqlSelect(queryCache, triggers, this);
   self._select.push(newSelect);
   return newSelect;
 };
+
+LiveMysql.prototype._escapeQueryFun = function(query){
+  var self = this;
+  if(typeof query === 'function'){
+    var escId = self.db.escapeId;
+    var esc = self.db.escape.bind(self.db);
+    return query(esc, escId);
+  }
+  return query;
+};
+
+LiveMysql.prototype._removeSelect = function(select){
+  var self = this;
+  var index = self._select.indexOf(select);
+  if(index !== -1){
+    // Remove the select object from our list
+    self._select.splice(index, 1);
+    
+    var queryCache = select.queryCache;
+    var queryCacheIndex = queryCache.selects.indexOf(select);
+    if(queryCacheIndex !== -1){
+      // Remove the select object from the query cache's list and remove the
+      // query cache if no select objects are using it.
+      queryCache.selects.splice(queryCacheIndex, 1);
+      if(queryCache.selects.length === 0){
+        delete self._queryCache[queryCache.query];
+      }
+    }
+    
+    return true;
+  }else{
+    return false;
+  }
+}
 
 LiveMysql.prototype.pause = function(){
   var self = this;

--- a/lib/LiveMysqlSelect.js
+++ b/lib/LiveMysqlSelect.js
@@ -3,9 +3,9 @@
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
-function LiveMysqlSelect(query, triggers, base){
-  if(!query)
-    throw new Error('query required');
+function LiveMysqlSelect(queryCache, triggers, base){
+  if(!queryCache)
+    throw new Error('queryCache required');
   if(!(triggers instanceof Array))
     throw new Error('triggers array required');
   if(typeof base !== 'object')
@@ -15,31 +15,40 @@ function LiveMysqlSelect(query, triggers, base){
   EventEmitter.call(self);
   self.triggers = triggers;
   self.base = base;
-  self.lastUpdate = 0;
-  self.query = self._escapeQueryFun(query);
   self.data = [];
-  self.initialized = false;
-
-  if(self.query in base._resultsBuffer){
-    setTimeout(function(){
-      self._setRows(base._resultsBuffer[self.query]);
-    }, 1);
+  self.queryCache = queryCache;
+  queryCache.selects.push(self);
+  
+  if(queryCache.initialized){
+    var refLastUpdate = queryCache.lastUpdate;
+    
+    // Trigger events for existing data
+    setTimeout(function() {
+      if(queryCache.lastUpdate !== refLastUpdate){
+        // Query cache has been updated since this select object was created;
+        // our data would've been updated already.
+        return;
+      }
+      
+      self.emit('update', queryCache.data);
+      
+      if(queryCache.data.length !== 0 && !self.base.settings.skipDiff){
+        var diff = queryCache.data.map(function(row, index) { return [ 'added', row, index ]; });
+        diff.forEach(function(evt){
+          self.emit.apply(self, evt);
+          // New row added to end
+          self.data[evt[2]] = evt[1];
+        });
+        // Output all difference events in a single event
+        self.emit('diff', diff);
+      }
+    }, 50);
   }else{
-    self.update();
+    queryCache.invalidate();
   }
 }
 
 util.inherits(LiveMysqlSelect, EventEmitter);
-
-LiveMysqlSelect.prototype._escapeQueryFun = function(query){
-  var self = this;
-  if(typeof query === 'function'){
-    var escId = self.base.db.escapeId;
-    var esc = self.base.db.escape.bind(self.base.db);
-    return query(esc, escId);
-  }
-  return query;
-};
 
 LiveMysqlSelect.prototype.matchRowEvent = function(event){
   var self = this;
@@ -71,104 +80,9 @@ LiveMysqlSelect.prototype.matchRowEvent = function(event){
   return false;
 };
 
-LiveMysqlSelect.prototype._setRows = function(rows){
-  var self = this;
-  var diff = [];
-
-  // Determine what changes before updating cache in order to
-  // be able to skip all event emissions if no change
-  // TODO update this algorithm to use less data
-  rows.forEach(function(row, index){
-    if(self.data.length - 1 < index){
-      diff.push([ 'added', row, index ]);
-    }else if(JSON.stringify(self.data[index]) !== JSON.stringify(row)){
-      diff.push([ 'changed', self.data[index], row, index ]);
-    }
-  });
-
-  if(self.data.length > rows.length){
-    for(var i = self.data.length - 1; i >= rows.length; i--){
-      diff.push([ 'removed', self.data[i], i ]);
-    }
-  }
-
-  if(diff.length !== 0){
-    self.emit('update', rows);
-
-    diff.forEach(function(evt){
-      if(!self.base.settings.skipDiff){
-        self.emit.apply(self, evt);
-      }
-      switch(evt[0]){
-        case 'added':
-          // New row added to end
-          self.data[evt[2]] = evt[1];
-          break;
-        case 'changed':
-          // Update row data reference
-          self.data[evt[3]] = evt[2];
-          break;
-        case 'removed':
-          // Remove extra rows off the end
-          self.data.splice(evt[2], 1);
-          break;
-      }
-    });
-    if(!self.base.settings.skipDiff){
-      // Output all difference events in a single event
-      self.emit('diff', diff);
-    }
-  }else if(self.initialized === false){
-    // If the result set initializes to 0 rows, it still needs to output an
-    //  update event.
-    self.emit('update', rows);
-  }
-
-  self.initialized = true;
-
-  self.lastUpdate = Date.now();
-};
-
-LiveMysqlSelect.prototype.update = function(callback){
-  var self = this;
-
-  function _update(){
-    self.base.db.query(self.query, function(error, rows){
-      if(error){
-        self.emit('error', error);
-        callback && callback.call(self, error);
-      }else{
-        self.base._resultsBuffer[self.query] = rows;
-        self._setRows(rows);
-        callback && callback.call(self, undefined, rows);
-      }
-    });
-  }
-
-  if(self.base.settings.minInterval === undefined){
-    _update();
-  }else if(self.lastUpdate + self.base.settings.minInterval < Date.now()){
-    _update();
-  }else{ // Before minInterval
-    if(!self._updateTimeout){
-      self._updateTimeout = setTimeout(function(){
-        delete self._updateTimeout;
-        _update();
-      }, self.lastUpdate + self.base.settings.minInterval - Date.now());
-    }
-  }
-};
-
 LiveMysqlSelect.prototype.stop = function(){
   var self = this;
-  
-  var index = self.base._select.indexOf(self);
-  if(index !== -1){
-    self.base._select.splice(index, 1);
-    return true;
-  }else{
-    return false;
-  }
+  return self.base._removeSelect(self);
 };
 
 LiveMysqlSelect.prototype.active = function(){

--- a/lib/QueryCache.js
+++ b/lib/QueryCache.js
@@ -1,0 +1,159 @@
+ /* mysql-live-select, MIT License wj32.64@gmail.com
+   lib/QueryCache.js - Query Results Cache Class */
+
+// Many LiveMysqlSelect objects can share the same query cache if they have the
+// same query string.
+
+function QueryCache(query, base){
+  if(!query)
+    throw new Error('query required');
+
+  var self = this;
+  self.base = base;
+  self.query = query;
+  self.needUpdate = false;
+  self.updating = false;
+  self.lastUpdate = 0;
+  self.data = [];
+  self.selects = [];
+  self.initialized = false;
+}
+
+QueryCache.prototype._setDataOnSelects = function(){
+  var self = this;
+  for(var i = 0; i < self.selects.length; i++){
+    self.selects[i].data = self.data;
+  }
+};
+
+QueryCache.prototype._emitOnSelects = function(name, arg){
+  var self = this;
+  for(var i = 0; i < self.selects.length; i++){
+    self.selects[i].emit(name, arg);
+  }
+};
+
+QueryCache.prototype._emitApplyOnSelects = function(evt){
+  var self = this;
+  for(var i = 0; i < self.selects.length; i++){
+    var select = self.selects[i];
+    select.emit.apply(select, evt);
+  }
+};
+
+QueryCache.prototype._setRows = function(rows){
+  var self = this;
+  var diff = [];
+
+  // Determine what changes before updating cache in order to
+  // be able to skip all event emissions if no change
+  // TODO update this algorithm to use less data
+  rows.forEach(function(row, index){
+    if(self.data.length - 1 < index){
+      diff.push([ 'added', row, index ]);
+    }else if(JSON.stringify(self.data[index]) !== JSON.stringify(row)){
+      diff.push([ 'changed', self.data[index], row, index ]);
+    }
+  });
+
+  if(self.data.length > rows.length){
+    for(var i = self.data.length - 1; i >= rows.length; i--){
+      diff.push([ 'removed', self.data[i], i ]);
+    }
+  }
+
+  if(diff.length !== 0){
+    self._emitOnSelects('update', rows);
+    // Make sure the relevant select objects have the right data array.
+    self._setDataOnSelects();
+
+    diff.forEach(function(evt){
+      if(!self.base.settings.skipDiff){
+        self._emitApplyOnSelects(evt);
+      }
+      switch(evt[0]){
+        case 'added':
+          // New row added to end
+          self.data[evt[2]] = evt[1];
+          break;
+        case 'changed':
+          // Update row data reference
+          self.data[evt[3]] = evt[2];
+          break;
+        case 'removed':
+          // Remove extra rows off the end
+          self.data.splice(evt[2], 1);
+          break;
+      }
+    });
+    if(!self.base.settings.skipDiff){
+      // Output all difference events in a single event
+      self._emitOnSelects('diff', diff);
+    }
+  }else if(self.initialized === false){
+    // If the result set initializes to 0 rows, it still needs to output an
+    //  update event.
+    self._emitOnSelects('update', rows);
+  }
+
+  self.initialized = true;
+  self.lastUpdate = Date.now();
+};
+
+QueryCache.prototype.matchRowEvent = function(event){
+  var self = this;
+  for(var i = 0; i < self.selects.length; i++){
+    var select = self.selects[i];
+    if (select.matchRowEvent(event)){
+      return true;
+    }
+  }
+  return false;
+};
+
+QueryCache.prototype.canSkipRowEvent = function(){
+  var self = this;
+  return self.base.settings.canSkipRowEvents && self._updateTimeout !== undefined;
+};
+
+QueryCache.prototype.invalidate = function(){
+  var self = this;
+
+  function update(){
+    // Refuse to send more than one query out at a time. Note that the code
+    // below always sets needUpdate to true; when the current query finishes
+    // running we will check needUpdate again and re-run the query if necessary.
+    if(self.updating){
+      self.needUpdate = true;
+      return;
+    }
+    self.updating = true;
+    self.needUpdate = false;
+    self.base.db.query(self.query, function(error, rows){
+      self.updating = false;
+      if(error){
+        self._emitOnSelects('error', error);
+      }else{
+        self._setRows(rows);
+        if(self.needUpdate){
+          update();
+        }
+      }
+    });
+  }
+
+  if(self.base.settings.minInterval === undefined){
+    update();
+  }else if(self.lastUpdate + self.base.settings.minInterval < Date.now()){
+    update();
+  }else{ // Before minInterval
+    if(!self._updateTimeout){
+      self._updateTimeout = setTimeout(function(){
+        delete self._updateTimeout;
+        update();
+      }, self.lastUpdate + self.base.settings.minInterval - Date.now());
+    }
+  }
+};
+
+module.exports = QueryCache;


### PR DESCRIPTION
mysql-live-select is incredibly useful! While trying to use mysql-live-select in production however, we've noticed two major problems that can cause our server to come to a grinding halt:

1. LiveMysql._resultsBuffer[query] never gets invalidated when no LiveMysqlSelect objects for that query are active: If a LiveMysqlSelect object 'X' is created for a query and the query is executed, the results will be stored in _resultsBuffer. Suppose that 'X' is destroyed because it is no longer needed, and subsequently a few changes are made to the database. Any new LiveMysqlSelect object with the same query string as 'X' will continue to use the results in _resultsBuffer even though they are stale.

2. Even slightly large values of minInterval drastically slow down binlog event processing when
there are many LiveMysqlSelect objects active. This is caused by _nextSelect being called only after the database query has completed, preventing other LiveMysqlSelect objects from being processed. Furthermore, because of the logic in the zongji.on('binlog', ...) callback it seems that many duplicate queries are started for the same query string if many binlog events are received in a short period of time.

Here I've significantly changed the way in which results are cached and shared between different LiveMysqlSelect objects with the same query string.